### PR TITLE
TCL output log - legacy Mi-V soft-processor cores are not recommended

### DIFF
--- a/Libero_Projects/PF_Splash_Kit_ES_MIV_RV32IMAF_BaseDesign.tcl
+++ b/Libero_Projects/PF_Splash_Kit_ES_MIV_RV32IMAF_BaseDesign.tcl
@@ -60,6 +60,16 @@ proc  base_design_built { }\
 	puts "--------------------------------------------------------------------------------------------------------- \n"
 }
 
+proc  legacy_core_msg { }\
+{
+	puts "\n---------------------------------------------------------------------------------------------------------"
+    puts "This Libero design uses a legacy Mi-V soft processor core. Legacy Mi-V soft processors"
+	puts "are not recommended for new designs. "
+	puts ""
+	puts "MIV_RV32 is recommended for new designs."
+	puts "--------------------------------------------------------------------------------------------------------- \n"
+}
+
 proc download_cores_all_cfgs  { }\
 {
 	download_core -vlnv {Actel:DirectCore:CoreUARTapb:5.7.100} -location {www.microchip-ip.com/repositories/DirectCore}
@@ -198,3 +208,4 @@ if {"$design_flow_stage" == "SYNTHESIZE"} then {
 } else {
 	no_second_argument_entered
 }
+legacy_core_msg

--- a/Libero_Projects/PF_Splash_Kit_ES_MIV_RV32IMA_BaseDesign.tcl
+++ b/Libero_Projects/PF_Splash_Kit_ES_MIV_RV32IMA_BaseDesign.tcl
@@ -64,6 +64,16 @@ proc  base_design_built { }\
 	puts "--------------------------------------------------------------------------------------------------------- \n"
 }
 
+proc  legacy_core_msg { }\
+{
+	puts "\n---------------------------------------------------------------------------------------------------------"
+    puts "This Libero design uses a legacy Mi-V soft processor core. Legacy Mi-V soft processors"
+	puts "are not recommended for new designs. "
+	puts ""
+	puts "MIV_RV32 is recommended for new designs."
+	puts "--------------------------------------------------------------------------------------------------------- \n"
+}
+
 proc download_cores_all_cfgs  { }\
 {
 	download_core -vlnv {Actel:DirectCore:CoreUARTapb:5.7.100} -location {www.microchip-ip.com/repositories/DirectCore}
@@ -226,3 +236,4 @@ if {"$design_flow_stage" == "SYNTHESIZE"} then {
 } else {
 	no_second_argument_entered
 }
+legacy_core_msg

--- a/Libero_Projects/PF_Splash_Kit_MIV_RV32IMAF_BaseDesign.tcl
+++ b/Libero_Projects/PF_Splash_Kit_MIV_RV32IMAF_BaseDesign.tcl
@@ -60,6 +60,16 @@ proc  base_design_built { }\
 	puts "--------------------------------------------------------------------------------------------------------- \n"
 }
 
+proc  legacy_core_msg { }\
+{
+	puts "\n---------------------------------------------------------------------------------------------------------"
+    puts "This Libero design uses a legacy Mi-V soft processor core. Legacy Mi-V soft processors"
+	puts "are not recommended for new designs. "
+	puts ""
+	puts "MIV_RV32 is recommended for new designs."
+	puts "--------------------------------------------------------------------------------------------------------- \n"
+}
+
 proc download_cores_all_cfgs  { }\
 {
 	download_core -vlnv {Actel:DirectCore:CoreUARTapb:5.7.100} -location {www.microchip-ip.com/repositories/DirectCore}
@@ -198,3 +208,4 @@ if {"$design_flow_stage" == "SYNTHESIZE"} then {
 } else {
 	no_second_argument_entered
 }
+legacy_core_msg

--- a/Libero_Projects/PF_Splash_Kit_MIV_RV32IMA_BaseDesign.tcl
+++ b/Libero_Projects/PF_Splash_Kit_MIV_RV32IMA_BaseDesign.tcl
@@ -64,6 +64,16 @@ proc  base_design_built { }\
 	puts "--------------------------------------------------------------------------------------------------------- \n"
 }
 
+proc  legacy_core_msg { }\
+{
+	puts "\n---------------------------------------------------------------------------------------------------------"
+    puts "This Libero design uses a legacy Mi-V soft processor core. Legacy Mi-V soft processors"
+	puts "are not recommended for new designs. "
+	puts ""
+	puts "MIV_RV32 is recommended for new designs."
+	puts "--------------------------------------------------------------------------------------------------------- \n"
+}
+
 proc download_cores_all_cfgs  { }\
 {
 	download_core -vlnv {Actel:DirectCore:CoreUARTapb:5.7.100} -location {www.microchip-ip.com/repositories/DirectCore}
@@ -226,3 +236,4 @@ if {"$design_flow_stage" == "SYNTHESIZE"} then {
 } else {
 	no_second_argument_entered
 }
+legacy_core_msg


### PR DESCRIPTION
- A message was added to the Libero's TCL script output log for legacy Mi-V cores, to let the user know that legacy Mi-V soft-processor cores are not recommended for new Mi-V designs.